### PR TITLE
Safe custom element content processing

### DIFF
--- a/src/components/Timeline/TimelineControls.tsx
+++ b/src/components/Timeline/TimelineControls.tsx
@@ -48,6 +48,7 @@ const TimelineControls = (props: {
             <div className="tooltip" data-tip="Create custom element">
               <button className="btn btn-sm btn-ghost" onClick={createElement}>
                 <i className="bi bi-plus-lg text-lg"></i>
+                <span>Element</span>
               </button>
             </div>
           </>

--- a/src/types/parsedVideostrate.ts
+++ b/src/types/parsedVideostrate.ts
@@ -276,6 +276,22 @@ export class ParsedVideostrate {
     return element
   }
 
+  private parseCustomElementContent(content: string): HTMLElement {
+    const parser = new DOMParser()
+    const document = parser.parseFromString(content, "text/html")
+
+    // if the content is not a valid html or has multiple root elements, wrap it in a div
+    if (document.body.children.length !== 1) {
+      const wrapper = document.createElement("div")
+      wrapper.innerHTML = content
+      return wrapper
+    }
+
+    let htmlElement = document.body.firstChild as HTMLElement
+    htmlElement = ParsedVideostrate.cleanTree(htmlElement)
+    return htmlElement
+  }
+
   public addCustomElement(
     name: string,
     content: string,
@@ -284,10 +300,7 @@ export class ParsedVideostrate {
     type: VideoElementType = "custom",
     nodeType = "div"
   ) {
-    const parser = new DOMParser()
-    const document = parser.parseFromString(content, "text/html")
-    let htmlElement = document.body.firstChild as HTMLElement
-    htmlElement = ParsedVideostrate.cleanTree(htmlElement)
+    const htmlElement = this.parseCustomElementContent(content)
     const parent = htmlElement?.parentNode
     const wrapper = document.createElement("div")
     parent?.replaceChild(wrapper, htmlElement)
@@ -304,7 +317,7 @@ export class ParsedVideostrate {
         nodeType,
         type,
         offset: 0,
-        content,
+        content: htmlElement.outerHTML,
         outerHtml: wrapper.outerHTML,
         layer,
         speed: 1,
@@ -319,7 +332,8 @@ export class ParsedVideostrate {
     const element = this.all.find((e) => e.id === id)
     if (element) {
       const customElement = element as CustomElement
-      customElement.content = content
+      const htmlElement = this.parseCustomElementContent(content)
+      customElement.content = htmlElement.outerHTML
     } else {
       throw new Error(`Element with id ${id} not found`)
     }


### PR DESCRIPTION
The new implementation pre-processes custom element content when creating or updating one.
The content gets wrapped in a div when:

- it is empty
- it is just string content, not html
- it has multiple root elements